### PR TITLE
Add flexibility for tests that can FAIL in update mode but still update the snapshot file.

### DIFF
--- a/src/snaptol/snapshot.py
+++ b/src/snaptol/snapshot.py
@@ -42,20 +42,32 @@ def auto_update(method: F) -> F:
     @wraps(method)
     def wrapper(snapshot: Snapshot, value: Any, *args, **kwargs):
         # Do the comparison and store any exceptions for later.
+        comparison_matched = False
+        caught_exception = None
+        problem_found = False
+
         if snapshot.snapshot_found:
             try:
                 method(value, snapshot.expected, *args, **kwargs)
-                success = True
-                caught_exception = None
+                comparison_matched = True
             except AssertionError as exc:
-                success = False
+                # The comparison has not matched, this is only a problem if we are NOT in update mode.
                 caught_exception = exc
-        else:
-            success = False
+                problem_found = not snapshot.snaptol_update
+            except TypeError as exc:
+                caught_exception = exc
+                problem_found = not snapshot.snaptol_update
+        elif not snapshot.snaptol_update:
+            # If we are in update mode, we don't care that the snapshot is missing.
             caught_exception = FileNotFoundError("Snapshot file not found.")
+            problem_found = True
+
+        if snapshot.snaptol_update:
+            write_snapshot(snapshot.snapshot_file, value)
+            _uncache_test(snapshot.cache, snapshot.nodeid)
 
         # Show a diff if requested and if a difference exists.
-        if snapshot.show_diff and not success:
+        if snapshot.show_diff and not comparison_matched:
             _store_test_diff(
                 snapshot.config,
                 snapshot.snapshot_file,
@@ -63,12 +75,7 @@ def auto_update(method: F) -> F:
                 after=value,
             )
 
-        if snapshot.snaptol_update:
-            write_snapshot(snapshot.snapshot_file, value)
-            _uncache_test(snapshot.cache, snapshot.nodeid)
-            return True
-
-        if not success:
+        if problem_found:
             _cache_failed_test(
                 snapshot.cache, snapshot.nodeid, snapshot.snapshot_file, value
             )
@@ -138,17 +145,32 @@ class Snapshot:
 
     def __eq__(self, value: Any) -> bool:
         # Do the comparison and store any exceptions for later.
+        comparison_matched = False
+        caught_exception = None
+        problem_found = False
+
         if self.snapshot_found:
-            success = compare_intelligent(
-                self.expected, value, self.rtol, self.atol, self.equal_nan
-            )
-            caught_exception = None
-        else:
-            success = False
+            try:
+                comparison_matched = compare_intelligent(
+                    value, self.expected, self.rtol, self.atol, self.equal_nan
+                )
+                # If the comparison has not matched, this is only a problem if we are NOT in update mode.
+                if not comparison_matched:
+                    problem_found = not self.snaptol_update
+            except TypeError as exc:
+                caught_exception = exc
+                problem_found = not self.snaptol_update
+        elif not self.snaptol_update:
+            # If we are in update mode, we don't care that the snapshot is missing.
             caught_exception = FileNotFoundError("Snapshot file not found.")
+            problem_found = True
+
+        if self.snaptol_update:
+            write_snapshot(self.snapshot_file, value)
+            _uncache_test(self.cache, self.nodeid)
 
         # Show a diff if requested and if a difference exists.
-        if self.show_diff and not success:
+        if self.show_diff and not comparison_matched:
             _store_test_diff(
                 self.config,
                 self.snapshot_file,
@@ -156,12 +178,7 @@ class Snapshot:
                 after=value,
             )
 
-        if self.snaptol_update:
-            write_snapshot(self.snapshot_file, value)
-            _uncache_test(self.cache, self.nodeid)
-            return True
-
-        if not success:
+        if problem_found:
             _cache_failed_test(self.cache, self.nodeid, self.snapshot_file, value)
             if caught_exception is not None:
                 raise caught_exception from None

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -400,3 +400,44 @@ def test_parameterise(pytester):
     assert (pytester.path / "__snapshots__" / "test_a.py__test_a[1].json").exists()
     assert (pytester.path / "__snapshots__" / "test_a.py__test_a[a].json").exists()
     assert (pytester.path / "__snapshots__" / "test_a.py__test_a[True].json").exists()
+
+
+def test_compare_different_types(pytester):
+    # Create a test for strings.
+    pytester.makepyfile(
+        test_ab="""
+    import numpy as np
+    def test_a(snaptolshot):
+        assert snaptolshot == np.array(['h', 'i'], dtype='<U1')
+    def test_b(snaptolshot):
+        assert snaptolshot.assert_allclose(np.array(['h', 'i'], dtype='<U1'))
+    """
+    )
+
+    # Create snapshots.
+    pytester.runpytest_subprocess("--snaptol-update-all").assert_outcomes(passed=2)
+    assert (pytester.path / "__snapshots__" / "test_ab.py__test_a.json").exists()
+    assert (pytester.path / "__snapshots__" / "test_ab.py__test_b.json").exists()
+
+    # Rewrite the test for floats - the comparison will fail.
+    pytester.makepyfile(
+        test_ab="""
+    import numpy as np
+    def test_a(snaptolshot):
+        assert snaptolshot == np.array([0.0, 1.0], dtype='float64')
+    def test_b(snaptolshot):
+        assert snaptolshot.assert_allclose(np.array([0.0, 1.0], dtype='float64'))
+    """
+    )
+
+    # Remove the cache to absolutely ensure Python runs on the overwritten test_a file and not the original.
+    shutil.rmtree(pytester.path / "__pycache__", ignore_errors=True)
+
+    # Normal mode -> should fail as we have a type incompatibility.
+    pytester.runpytest_subprocess().assert_outcomes(failed=2)
+
+    # Update mode -> should pass despite the type incompatibility.
+    pytester.runpytest_subprocess("--snaptol-update-all").assert_outcomes(passed=2)
+
+    # Normal mode -> should now pass as there should no longer be a type incompatibility.
+    pytester.runpytest_subprocess().assert_outcomes(passed=2)


### PR DESCRIPTION
Improve the logic of the equality (both `__eq__` and `wrapper`) functions. Check for `TypeError` and handle this appropriately if not in update mode. `TypeError` and `AssertionError` do not raise if we are in update mode. Clean up the logic of the equality functions so it is more readable. Correct the order of the value and expected_value in `__eq__`.

In update mode:
- Does not raise any `AssertionError` or `TypeError`.
- Updates the file regardless.

In normal mode:
- `AssertionError` or `TypeError` are raised if thrown in `compare_intelligent`.

Along with #30, closes #23.

@LiamPattinson do you think the above logic is OK?