### PR TITLE
Suppress tracebacks from snaptol in pytest

### DIFF
--- a/src/snaptol/snapshot.py
+++ b/src/snaptol/snapshot.py
@@ -41,6 +41,7 @@ def auto_update(method: F) -> F:
 
     @wraps(method)
     def wrapper(snapshot: Snapshot, value: Any, *args, **kwargs):
+        __tracebackhide__ = True  # Hide traceback for py.test
         # Do the comparison and store any exceptions for later.
         comparison_matched = False
         caught_exception = None
@@ -144,6 +145,7 @@ class Snapshot:
             self.snapshot_found = False
 
     def __eq__(self, value: Any) -> bool:
+        __tracebackhide__ = True  # Hide traceback for py.test
         # Do the comparison and store any exceptions for later.
         comparison_matched = False
         caught_exception = None


### PR DESCRIPTION
This gives nicer output, and hides all the snaptol machinery in tests. See docs: https://docs.pytest.org/en/stable/example/simple.html#writing-well-integrated-assertion-helpers

Before:

```
__________________________________________________________________________________________________ test_default __________________________________________________________________________________________________

snaptolshot = Snapshot(nodeid='test_snap.py::test_default', snapshot_file=PosixPath('/tmp/snaptoltest/__snapshots__/test_snap.py__te...False, rtol=1e-05, atol=1e-08, equal_nan=False, cache=Cache(), config=<_pytest.config.Config object at 0x7f7d85e69400>)

    def test_default(snaptolshot):
        result = compute_something()
>       assert snaptolshot(rtol=1e-5) == result
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test_snap.py:12: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Snapshot(nodeid='test_snap.py::test_default', snapshot_file=PosixPath('/tmp/snaptoltest/__snapshots__/test_snap.py__te...False, rtol=1e-05, atol=1e-08, equal_nan=False, cache=Cache(), config=<_pytest.config.Config object at 0x7f7d85e69400>)
value = array([13.2567, 23.4486, 19.8765])

    def __eq__(self, value: Any) -> bool:
        # Do the comparison and store any exceptions for later.
        comparison_matched = False
        caught_exception = None
        problem_found = False
    
        if self.snapshot_found:
            try:
                comparison_matched = compare_intelligent(
                    value, self.expected, self.rtol, self.atol, self.equal_nan
                )
                # If the comparison has not matched, this is only a problem if we are NOT in update mode.
                if not comparison_matched:
                    problem_found = not self.snaptol_update
            except TypeError as exc:
                caught_exception = exc
                problem_found = not self.snaptol_update
        elif not self.snaptol_update:
            # If we are in update mode, we don't care that the snapshot is missing.
            caught_exception = FileNotFoundError("Snapshot file not found.")
            problem_found = True
    
        if self.snaptol_update:
            write_snapshot(self.snapshot_file, value)
            _uncache_test(self.cache, self.nodeid)
    
        # Show a diff if requested and if a difference exists.
        if self.show_diff and not comparison_matched:
            _store_test_diff(
                self.config,
                self.snapshot_file,
                before=self.expected if self.snapshot_found else SENTINEL,
                after=value,
            )
    
        if problem_found:
            _cache_failed_test(self.cache, self.nodeid, self.snapshot_file, value)
            if caught_exception is not None:
>               raise caught_exception from None
E               FileNotFoundError: Snapshot file not found.

/home/peter/Codes/snaptol/src/snaptol/snapshot.py:185: FileNotFoundError
```

After:

```
__________________________________________________________________________________________________ test_default __________________________________________________________________________________________________

snaptolshot = Snapshot(nodeid='test_snap.py::test_default', snapshot_file=PosixPath('/tmp/snaptoltest/__snapshots__/test_snap.py__te...False, rtol=1e-05, atol=1e-08, equal_nan=False, cache=Cache(), config=<_pytest.config.Config object at 0x7f4f9d315400>)

    def test_default(snaptolshot):
        result = compute_something()
>       assert snaptolshot(rtol=1e-5) == result
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: Snapshot file not found.

test_snap.py:12: FileNotFoundError
```