### PR TITLE
Add slightly nicer `__repr__`

### DIFF
--- a/src/snaptol/snapshot.py
+++ b/src/snaptol/snapshot.py
@@ -219,6 +219,9 @@ class Snapshot:
 
         return self.match(*args, **kwargs)
 
+    def __repr__(self):
+        return f"Snapshot({self.expected})"
+
     assert_allclose = auto_update(npt.assert_allclose)
     assert_array_almost_equal_nulp = auto_update(npt.assert_array_almost_equal_nulp)
     assert_array_max_ulp = auto_update(npt.assert_array_max_ulp)


### PR DESCRIPTION
When using plain `assert snaptolshot == ...`, pytest prints the `repr`, which is not super helpful and can be quite noisy. This just adds a very simple `__repr__` implementation to make this a bit easier to read.

Before:

```
E       AssertionError: assert Snapshot(nodeid='test_snap.py::test_default', snapshot_file=PosixPath('/tmp/snaptoltest/__snapshots__/test_snap.py__te...False, rtol=1e-05, atol=1e-08, equal_nan=False, cache=Cache(), config=<_pytest.config.Config object at 0x7f56d1211400>) == array([13.3567, 23.4486, 19.8765])
E        +  where Snapshot(nodeid='test_snap.py::test_default', snapshot_file=PosixPath('/tmp/snaptoltest/__snapshots__/test_snap.py__te...False, rtol=1e-05, atol=1e-08, equal_nan=False, cache=Cache(), config=<_pytest.config.Config object at 0x7f56d1211400>) = Snapshot(nodeid='test_snap.py::test_default', snapshot_file=PosixPath('/tmp/snaptoltest/__snapshots__/test_snap.py__te...False, rtol=1e-05, atol=1e-08, equal_nan=False, cache=Cache(), config=<_pytest.config.Config object at 0x7f56d1211400>)(rtol=1e-05)
```

After:

```
E       assert Snapshot([13.2567, 23.4486, 19.8765]) == array([13.3567, 23.4486, 19.8765])
E        +  where Snapshot([13.2567, 23.4486, 19.8765]) = Snapshot([13.2567, 23.4486, 19.8765])(rtol=1e-05)

```

It would be nice to go further and eliminate the `where` line, but I'm not sure how to that immediately